### PR TITLE
Added a `cwd` option

### DIFF
--- a/src/installer.js
+++ b/src/installer.js
@@ -146,7 +146,8 @@ module.exports.install = function install(deps, options) {
 
   // Ignore input, capture output, show errors
   var output = spawn.sync("npm", args, {
-    stdio: ["ignore", "pipe", "inherit"]
+    stdio: ["ignore", "pipe", "inherit"],
+    cwd: options.cwd || process.cwd()
   });
 
   if (output.status) {


### PR DESCRIPTION
This plugin is awesome, thank you; however, I'd like to specify where I want the modules to be installed (for me it's in the build folder for node projects).

I've added a `cwd` option to the `options` object that defaults to `process.cwd()` so I can specify where I want the plugin to stick the modules folder.

I hope that's ok, and thanks for the great work.